### PR TITLE
Mnt/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Citation
 
-If you use the tool from this repository, please cite the following papers:
+If you use TrUE-Net, please cite the following papers:
 
 - Sundaresan, V., Zamboni, G., Rothwell, P.M., Jenkinson, M. and Griffanti, L., 2021. Triplanar ensemble U-Net model for white matter hyperintensities segmentation on MR images. Medical Image Analysis, p.102184. [DOI: https://doi.org/10.1016/j.media.2021.102184] (preprint available at https://doi.org/10.1101/2020.07.24.219485)
 - Sundaresan, V., Zamboni, G., Dinsdale, N. K., Rothwell, P. M., Griffanti, L., & Jenkinson, M. (2021). Comparison of domain adaptation techniques for white matter hyperintensity segmentation in brain MR images. bioRxiv. [DOI: https://doi.org/10.1101/2021.03.12.435171] (accepted in Medical Image Analysis, DOI to be updated soon).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
  - [technical details](#technical-details)
 
 ## Citation
-Article currently available at: https://doi.org/10.1016/j.media.2021.102184
 
 If you use the tool from this repository, please cite the following papers:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And for options and inputs for each sub-command, type:
 truenet <subcommand> --help (e.g. truenet train --help)
 ```
 ## Preprocessing and preparing data for truenet
-T1-weighted and/or FLAIR images, or similar, can be used as inputs for truenet. A series of preprocessing operations needs to be applied to any image that you want to use truenet on. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
+T1-weighted and/or FLAIR images, or similar (e.g. T2-weighted images), can be used as inputs for truenet. A series of preprocessing operations needs to be applied to any image that you want to use truenet on. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
 
 This script performs the following steps:
  - reorienting image to the standard MNI space (using FSL FLIRT)
@@ -59,10 +59,11 @@ This script performs the following steps:
 Usage: prepare_truenet_data <FLAIR_image_name> <T1_image_name> <output_basename>
  
 The script prepares the FLAIR and T1 data to be used in FSL truenet with a specified output basename
-FLAIR_image_name  	name of the input unprocessed FLAIR image
-T1_image_name 	name of the input unprocessed T1 image
-output_basename 	name to be used for the processed FLAIR and T1 images (along with the absolute path); 
-                     output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and output_basename_WMmask.nii.gz will be saved
+FLAIR_image_name: name of the input unprocessed FLAIR image
+T1_image_name: name of the input unprocessed T1 image
+output_basename: name to be used for the processed FLAIR and T1 images (along with the absolute path); 
+
+output names are: output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and output_basename_WMmask.nii.gz will be saved
 ```
 **Example:**
 prepare_truenet_data ...
@@ -94,7 +95,9 @@ When performing a training from scratch, the situation is similar to that for fi
 ### Naming conventions
 
 When running truenet it is necessary to use certain specific names and locations for files:
- - 
+ - for segmentation (_evaluate_ mode) the images inside the input directory need to be named like the outputs from _prepare_truenet_data_ :
+   - that is: the FLAIR and T1 volumes should be named as '<basename>_FLAIR.nii.gz' and '<basename>_T1.nii.gz'respectively
+ - for training or fine-tuning, labelled images (i.e. manual segmentations) need to be named _<subject>_manualmask.nii.gz_ (where the _<subject>_ part needs to be replaced with your subject identifier, e.g. sub-001)
  - each output directory that is specified must already exist; if not, use _mkdir_ to create it prior to running truenet
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ output names are: output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and ou
 ```
 **Example:**
 
-`prepare_truenet_data FLAIR.nii.gz T1.nii.gz subject001`
+`prepare_truenet_data FLAIR.nii.gz T1.nii.gz sub001`
 
 ## Simple usage
 
@@ -106,7 +106,7 @@ When running truenet it is necessary to use certain specific names and locations
 
 ### Examples
 
- - Run a segmentation on preprocessed data (from subject 1 in dataset A). 
+ - Run a segmentation on preprocessed data (from subject 1 in dataset A, stored in directory DatasetA/sub001 and containing files names sub001_T1.nii.gz and sub001_FLAIR.nii.gz, as created by `prepare_truenet_data`). 
 
 `mkdir DatasetA/results001`
 
@@ -117,6 +117,8 @@ When running truenet it is necessary to use certain specific names and locations
 `mkdir DatasetA/model_finetuned`
 
 `truenet fine_tune -i DatasetA/Training-pt -m ~/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/model_finetuned -l DatasetA/Training-pt -loss nweighted`
+
+ - Training a model from scratch
 
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And for options and inputs for each sub-command, type:
 truenet <subcommand> --help (e.g. truenet train --help)
 ```
 ## Preprocessing and preparing data for truenet
-T1-weighted and/or FLAIR images, or similar, can be used as inputs for truenet. A series of preprocessing operations needs to be applied to the images. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
+T1-weighted and/or FLAIR images, or similar, can be used as inputs for truenet. A series of preprocessing operations needs to be applied to any image that you want to use truenet on. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
 
 This script performs the following steps:
  - reorienting image to the standard MNI space (using FSL FLIRT)

--- a/README.md
+++ b/README.md
@@ -108,10 +108,16 @@ When running truenet it is necessary to use certain specific names and locations
 
  - Run a segmentation on preprocessed data (from subject 1 in dataset A):
 
+`mkdir DatasetA/results-001`
+
 `truenet evaluate -i DatasetA/sub-001 -m /home/myname/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/results-001`
 
- - Fine-tune an existing model using images and labels from XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXx
+ - Fine-tune an existing model using images and labels from XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+`mkdir DatasetA/model_finetuned`
+
+`truenet fine_tune -i DatasetA/Training-set -m /home/mark/Research/Truenet/Set1/model/Truenet_model_weights_beforeES -l DatasetA/Training-set -o DatasetA/model_finetuned -loss nweighted`
+????????????????????????????????
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,43 @@
 # Triplanar U-Net ensemble network (TrUE-Net) model 
 
-## Contents
- - [citation](#citation)
- - dependencies
- - installation
- - simple usage
- - advanced usage
- - technical details
-
 ## DL tool for white matter hyperintensities segmentation
 
-### Citation
+## Contents
+ - [citation](#citation)
+ - [dependencies](#dependencies)
+ - [installation](#installation)
+ - [preprocessing](#preprocessing-and-preparing-data-for-truenet)
+ - [simple usage](#simple-usage)
+ - [advanced usage](#advanced-usage)
+ - [technical details](#technical-details)
+
+## Citation
 Article currently available at: https://doi.org/10.1016/j.media.2021.102184
 
+If you use the tool from this repository, please cite the following papers:
 
-#### Dependencies for prepare_truenet_data:
-- FMRIB software library (FSL) 6.0
-- Python dependencies:
+- Sundaresan, V., Zamboni, G., Rothwell, P.M., Jenkinson, M. and Griffanti, L., 2021. Triplanar ensemble U-Net model for white matter hyperintensities segmentation on MR images. Medical Image Analysis, p.102184. [DOI: https://doi.org/10.1016/j.media.2021.102184] (preprint available at https://doi.org/10.1101/2020.07.24.219485)
+- Sundaresan, V., Zamboni, G., Dinsdale, N. K., Rothwell, P. M., Griffanti, L., & Jenkinson, M. (2021). Comparison of domain adaptation techniques for white matter hyperintensity segmentation in brain MR images. bioRxiv. [DOI: https://doi.org/10.1101/2021.03.12.435171] (accepted in Medical Image Analysis, DOI to be updated soon).
+
+
+## Dependencies
+- Main truenet dependencies:
   - Python > 3.6
   - PyTorch=1.5.0
+- Extra dependencies for pre-processing:
+  - FMRIB software library (FSL) 6.0
 
-## TrUE-Net architecture:
-<img
-src="images/main_architecture_final.png"
-alt="Triplanar U-Net ensemble network (TrUE-Net). (a) U-Net model used in individual planes, (b) Overall TrUE-Net architecture."
-/>
 
-### Applying spatial weights in the loss function:
-We used a weighted sum of the voxel-wise cross-entropy loss function and the Dice loss as the total cost function. We weighted the CE loss function using a spatial weight map (a sample shown in the figure) to up-weight the areas that are more likely to contain the less represented class (i.e. WMHs).
-<p align="center">
-       <img
-       src="images/spatial_weight_map.png"
-       alt="Spatial weight maps to be applied in the truenet loss function."
-       width=600
-       />
-</p>
-
-## To install the truenet tool
-Clone the git repository into your loacal directory and run:
+## Installation
+To install the truenet tool do the following:
+1. Clone the git repository into your local directory.  
+  - If you are not familiar with GitHub then the easiest way is to use the Clone button and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
+3. Run:
 ``` 
 python setup.py install
 ```
-To find about the subcommands available in truenet:
+3. Use the instructions in this document ([simple usage](#simple-usage) is recommended for beginners)
+4. More detailed lists of options for the subcommands are available in the command-line help:
 ```
 truenet --help
 ```
@@ -65,7 +61,14 @@ output_basename 	name to be used for the processed FLAIR and T1 images (along wi
                      output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and output_basename_WMmask.nii.gz will be saved
 ```
 
-## Running truenet
+## Simple usage
+
+
+## Advanced usage
+
+### Modes of operation
+
+Details of the different commands and their options are available through the command-line help
 
 Triplanar ensemble U-Net model, v1.0.1
 
@@ -77,46 +80,7 @@ Subcommands available:
     - truenet loo_validate  Leave-one-out validation of TrUE-Net model
 ```
 
-### Training the TrUE-Net model
-
-#### truenet train: training the TrUE-Net model from scratch, v1.0.1
-
-```
-Usage: truenet train -i <input_directory> -l <label_directory> -m <model_directory> [options] 
-
-
-Compulsory arguments:
-       -i, --inp_dir                 Path to the directory containing FLAIR and T1 images for training 
-       -l, --label_dir               Path to the directory containing manual labels for training 
-       -m, --model_dir               Path to the directory where the training model or weights need to be saved 
-   
-Optional arguments:
-       -tr_prop, --train_prop        Proportion of data used for training [0, 1]. The rest will be used for validation [default = 0.8]
-       -bfactor, --batch_factor      Number of subjects to be considered for each mini-epoch [default = 10]
-       -loss, --loss_function        Applying spatial weights to loss function. Options: weighted, nweighted [default=weighted]
-       -gdir, --gmdist_dir           Directory containing GM distance map images. Required if -loss=weighted [default = None]
-       -vdir, --ventdist_dir         Directory containing ventricle distance map images. Required if -loss=weighted [default = None]
-       -nclass, --num_classes        Number of classes to consider in the target labels (nclass=2 will consider only 0 and 1 in labels;
-                                     any additional class will be considered part of background class [default = 2]
-       -plane, --acq_plane           The plane in which the model needs to be trained. Options: axial, sagittal, coronal, all [default = all]
-       -da, --data_augmentation      Applying data augmentation [default = True]
-       -af, --aug_factor             Data inflation factor for augmentation [default = 2]
-       -sv_resume, --save_resume_training    Whether to save and resume training in case of interruptions (default-False)
-       -ilr, --init_learng_rate      Initial LR to use in scheduler [0, 0.1] [default=0.001]
-       -lrm, --lr_sch_mlstone        Milestones for LR scheduler (e.g. -lrm 5 10 - to reduce LR at 5th and 10th epochs) [default = 10]
-       -gamma, --lr_sch_gamma        Factor by which the LR needs to be reduced in the LR scheduler [default = 0.1]
-       -opt, --optimizer             Optimizer used for training. Options:adam, sgd [default = adam]
-       -bs, --batch_size             Batch size used for training [default = 8]
-       -ep, --num_epochs             Number of epochs for training [default = 60]
-       -es, --early_stop_val         Number of epochs to wait for progress (early stopping) [default = 20]
-       -sv_mod, --save_full_model    Saving the whole model instead of weights alone [default = False]
-       -cv_type, --cp_save_type      Checkpoint to be saved. Options: best, last, everyN [default = last]
-       -cp_n, --cp_everyn_N          If -cv_type=everyN, the N value [default = 10]
-       -v, --verbose                 Display debug messages [default = False]
-       -h, --help.                   Print help message
-```
-
-### Testing the TrUE-Net model
+### Applying the TrUE-Net model (performing segmentation)
 
 ### The pretrained models on MWSC and UKBB are currently available at https://drive.google.com/drive/folders/1iqO-hd27NSHHfKun125Rt-2fh1l9EiuT?usp=share_link
 
@@ -149,7 +113,7 @@ Optional arguments:
        -h, --help.                           Print help message
 ```
 
-### Fine-tuning the TrUE-Net model
+### Fine-tuning an existing TrUE-Net model
 
 #### truenet fine_tune: training the TrUE-Net model from scratch, v1.0.1
 <p align="center">
@@ -200,6 +164,45 @@ Optional arguments:
        -h, --help.                           Print help message
 ```
 
+### Training the TrUE-Net model from scratch
+
+#### truenet train: training the TrUE-Net model from scratch, v1.0.1
+
+```
+Usage: truenet train -i <input_directory> -l <label_directory> -m <model_directory> [options] 
+
+
+Compulsory arguments:
+       -i, --inp_dir                 Path to the directory containing FLAIR and T1 images for training 
+       -l, --label_dir               Path to the directory containing manual labels for training 
+       -m, --model_dir               Path to the directory where the training model or weights need to be saved 
+   
+Optional arguments:
+       -tr_prop, --train_prop        Proportion of data used for training [0, 1]. The rest will be used for validation [default = 0.8]
+       -bfactor, --batch_factor      Number of subjects to be considered for each mini-epoch [default = 10]
+       -loss, --loss_function        Applying spatial weights to loss function. Options: weighted, nweighted [default=weighted]
+       -gdir, --gmdist_dir           Directory containing GM distance map images. Required if -loss=weighted [default = None]
+       -vdir, --ventdist_dir         Directory containing ventricle distance map images. Required if -loss=weighted [default = None]
+       -nclass, --num_classes        Number of classes to consider in the target labels (nclass=2 will consider only 0 and 1 in labels;
+                                     any additional class will be considered part of background class [default = 2]
+       -plane, --acq_plane           The plane in which the model needs to be trained. Options: axial, sagittal, coronal, all [default = all]
+       -da, --data_augmentation      Applying data augmentation [default = True]
+       -af, --aug_factor             Data inflation factor for augmentation [default = 2]
+       -sv_resume, --save_resume_training    Whether to save and resume training in case of interruptions (default-False)
+       -ilr, --init_learng_rate      Initial LR to use in scheduler [0, 0.1] [default=0.001]
+       -lrm, --lr_sch_mlstone        Milestones for LR scheduler (e.g. -lrm 5 10 - to reduce LR at 5th and 10th epochs) [default = 10]
+       -gamma, --lr_sch_gamma        Factor by which the LR needs to be reduced in the LR scheduler [default = 0.1]
+       -opt, --optimizer             Optimizer used for training. Options:adam, sgd [default = adam]
+       -bs, --batch_size             Batch size used for training [default = 8]
+       -ep, --num_epochs             Number of epochs for training [default = 60]
+       -es, --early_stop_val         Number of epochs to wait for progress (early stopping) [default = 20]
+       -sv_mod, --save_full_model    Saving the whole model instead of weights alone [default = False]
+       -cv_type, --cp_save_type      Checkpoint to be saved. Options: best, last, everyN [default = last]
+       -cp_n, --cp_everyn_N          If -cv_type=everyN, the N value [default = 10]
+       -v, --verbose                 Display debug messages [default = False]
+       -h, --help.                   Print help message
+```
+
 ### Cross-validation of TrUE-Net model
 
 #### truenet cross_validate: cross-validation of the TrUE-Net model, v1.0.1  
@@ -238,10 +241,25 @@ Optional arguments:
        -h, --help.                           Print help message
 ```
 
-If you use the tool from this repository, please cite the following papers:
+## Technical Details
 
-- Sundaresan, V., Zamboni, G., Rothwell, P.M., Jenkinson, M. and Griffanti, L., 2021. Triplanar ensemble U-Net model for white matter hyperintensities segmentation on MR images. Medical Image Analysis, p.102184. [DOI: https://doi.org/10.1016/j.media.2021.102184] (preprint available at https://doi.org/10.1101/2020.07.24.219485)
-- Sundaresan, V., Zamboni, G., Dinsdale, N. K., Rothwell, P. M., Griffanti, L., & Jenkinson, M. (2021). Comparison of domain adaptation techniques for white matter hyperintensity segmentation in brain MR images. bioRxiv. [DOI: https://doi.org/10.1101/2021.03.12.435171] (accepted in Medical Image Analysis, DOI to be updated soon).
+### TrUE-Net architecture:
+<img
+src="images/main_architecture_final.png"
+alt="Triplanar U-Net ensemble network (TrUE-Net). (a) U-Net model used in individual planes, (b) Overall TrUE-Net architecture."
+/>
+
+### Applying spatial weights in the loss function:
+We used a weighted sum of the voxel-wise cross-entropy loss function and the Dice loss as the total cost function. We weighted the CE loss function using a spatial weight map (a sample shown in the figure) to up-weight the areas that are more likely to contain the less represented class (i.e. WMHs).
+<p align="center">
+       <img
+       src="images/spatial_weight_map.png"
+       alt="Spatial weight maps to be applied in the truenet loss function."
+       width=600
+       />
+</p>
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you use TrUE-Net, please cite the following papers:
 ## Installation
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
-  - If you are not familiar with GitHub then the easiest way is to use the Clone button (top, right hand side) on the [main truenet page](master) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
+  - If you are not familiar with GitHub then the easiest way is to use the Clone button (top, right hand side) on the [main truenet page](/) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
 3. Run:
 ``` 
 python setup.py install

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you use TrUE-Net, please cite the following papers:
 ## Installation
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
-  - If you are not familiar with GitHub then the easiest way is to use the Clone button (top, right hand side) on the [main truenet page](/) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
+  - If you are not familiar with GitHub then the easiest way is to use the button labelled "<> Code" (right hand side, just above the file list) on the [main truenet page](/) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
 3. Run:
 ``` 
 python setup.py install

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ prepare_truenet_data ...
 
 ## Simple usage
 
-#### Options 
+#### Modes 
 
 There are multiple options in how truenet can be used, but a simple summary is this:
  - to segment an image you use the _evaluate_ mode

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you use TrUE-Net, please cite the following papers:
 ## Installation
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
-  - If you are not familiar with GitHub then the easiest way is to use the button labelled "<> Code" (right hand side, just above the file list) on the [main truenet page](/) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
+  - If you are not familiar with GitHub then the easiest way is to use the button labelled "<> Code" (right hand side, just above the file list) on the [main truenet page](/) and select the **Download ZIP** option. After you've done this, move the zip file to where you want to have truenet installed and unzip it.
 3. Run:
 ``` 
 python setup.py install

--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ And for options and inputs for each sub-command, type:
 truenet <subcommand> --help (e.g. truenet train --help)
 ```
 ## Preprocessing and preparing data for truenet
-We used both T1-weighted and FLAIR images as inputs for the model. We reoriented the images to the standard MNI space, performed skull-stripping FSL BET and bias field correction using FSL FAST. We registered the T1-weighted image to the FLAIR using linear rigid-body registration.
+T1-weighted and/or FLAIR images, or similar, can be used as inputs for truenet. A series of preprocessing operations need to be applied to the images. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
 
-We obtained the white matter mask from a dilated and inverted cortical CSF tissue segmentation (combined with other deep grey exclusion masks, using FSL FAST) and make bianca mask command in FSL BIANCA (Griffanti et al., 2016).
+This script performs the following steps:
+ - reorienting image to the standard MNI space (using FSL FLIRT)
+ - skull-stripping (using FSL BET)
+ - bias field correction (using FSL FAST)
+ - T1-weighted images (or similar) need to be registered to the FLAIR (or whatever image was used to make the manual masks) using linear rigid-body registration (using FSL FLIRT).
+ - creating a white matter mask, obtained from a dilated and inverted cortical CSF tissue segmentation (combined with other deep grey exclusion masks, using FSL FAST) and the _make bianca mask_ command in FSL BIANCA (Griffanti et al., 2016).
 
 #### prepare_truenet_data
 ```
@@ -63,6 +68,15 @@ output_basename 	name to be used for the processed FLAIR and T1 images (along wi
 
 ## Simple usage
 
+There are multiple options in how truenet can be used, but a simple summary is this:
+ - to segment an image you use the _evaluate_ mode
+   - this requires an existing _model_ to be used, where a model is a network that has been trained on some dataset
+   - you can use a _pretrained_ model that is supplied with truenet (see [below](#pretrained-models))
+    - to use any of these pretrained models your images need to match relatively well to those used to train the model
+   - alternatively, you can use a model that you or someone else has trained from scratch (using the _train_ mode of truenet)
+   - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less data for training)
+
+### Examples
 
 ## Advanced usage
 
@@ -74,23 +88,26 @@ Triplanar ensemble U-Net model, v1.0.1
 
 ```  
 Subcommands available:
-    - truenet train         Training a TrUE-Net model from scratch
     - truenet evaluate      Applying a saved/pretrained TrUE-Net model for testing
     - truenet fine_tune     Fine-tuning a saved/pretrained TrUE-Net model from scratch
+    - truenet train         Training a TrUE-Net model from scratch
     - truenet loo_validate  Leave-one-out validation of TrUE-Net model
 ```
 
 ### Applying the TrUE-Net model (performing segmentation)
 
-### The pretrained models on MWSC and UKBB are currently available at https://drive.google.com/drive/folders/1iqO-hd27NSHHfKun125Rt-2fh1l9EiuT?usp=share_link
+#### Pretrained models
 
-#### When we integrate our tool into FSL, the models will be available in '$FSLDIR/data/truenet/Models' folder.
-#### But for testing purposes, you can download the models from the above drive link into a folder and set the folder as environment variable and then run truenet. 
-For doing this, once you download the models into a folder, please type the following in the command prompt: 
+ - Currently pretrained models, based on the [MWSC](linkhere) and UKBB [UK Biobank](linkhere) datasets, are available at: https://drive.google.com/drive/folders/1iqO-hd27NSHHfKun125Rt-2fh1l9EiuT?usp=share_link
+
+ - These will be integrated more fully into FSL in the future, where these models will be available in the '$FSLDIR/data/truenet/Models' folder.
+ 
+ - Currently, for testing purposes, you can download the models from the above drive link and place them into a folder of your choice. You then need to set the folder as an environment variable before running truenet. 
+To do this, once you download the models into a folder, please type the following in the command prompt: 
 ```
 export TRUENET_PRETRAINED_MODEL_PATH="/absolute/path/to/the/model/folder"
 ```
-and then run truenet commands.
+and then you can run truenet commands using the pretrained models as if they were integrated into FSL.
 
 #### truenet evaluate: evaluating the TrUE-Net model, v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ When performing a fine tuning operation it is necessary to supply your own label
 
 When performing a training from scratch, the situation is similar to that for fine tuning - you need a set of your own labelled images, but you need more in this case and we would recommend a minimum of NNNN images (though again, you can try your luck with less). 
 
+### Naming conventions
 
+When running truenet it is necessary to use certain specific names and locations for files:
+ - 
+ - each output directory that is specified must already exist; if not, use _mkdir_ to create it prior to running truenet
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,13 @@ When performing a training from scratch, the situation is similar to that for fi
 ### Naming conventions
 
 When running truenet it is necessary to use certain specific names and locations for files:
- - for segmentation (_evaluate_ mode) the images inside the input directory need to be named like the outputs from _prepare_truenet_data_ :
-   - that is: the FLAIR and T1 volumes should be named as '<basename>_FLAIR.nii.gz' and '<basename>_T1.nii.gz'respectively
- - for training or fine-tuning, labelled images (i.e. manual segmentations) need to be named _<subject>_manualmask.nii.gz_ (where the _<subject>_ part needs to be replaced with your subject identifier, e.g. sub-001)
+ - for segmentation (_evaluate_ mode) the images inside the specified input directory need to be named like the outputs from _prepare_truenet_data_ :
+   - that is: the FLAIR and/or T1 volumes should be named as *basename*_FLAIR.nii.gz and/or *basename*_T1.nii.gz respectively
  - each output directory that is specified must already exist; if not, use _mkdir_ to create it prior to running truenet
+ - for training or fine-tuning, all images need to be in one directory and named:
+   - preprocessed images: *subject*_FLAIR.nii.gz and/or *subject*_T1.nii.gz
+   - labelled images: (i.e. manual segmentations) need to be named *subject*_manualmask.nii.gz
+   - where the *subject* part needs to be replaced with your subject identifier (e.g. sub-001)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # Triplanar U-Net ensemble network (TrUE-Net) model 
 
+## Contents
+ - [citation](#citation)
+ - dependencies
+ - installation
+ - simple usage
+ - advanced usage
+ - technical details
+
 ## DL tool for white matter hyperintensities segmentation
 
-### Article currently available at: https://doi.org/10.1016/j.media.2021.102184
+### Citation
+Article currently available at: https://doi.org/10.1016/j.media.2021.102184
 
-#### Software versions used for truenet:
-- Python > 3.6
-- PyTorch=1.5.0
 
 #### Dependencies for prepare_truenet_data:
 - FMRIB software library (FSL) 6.0
+- Python dependencies:
+  - Python > 3.6
+  - PyTorch=1.5.0
 
 ## TrUE-Net architecture:
 <img

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ When running truenet it is necessary to use certain specific names and locations
 
 `mkdir DatasetA/model_finetuned`
 
-`truenet fine_tune -i DatasetA/Training-set -m /home/mark/Research/Truenet/Set1/model/Truenet_model_weights_beforeES -l DatasetA/Training-set -o DatasetA/model_finetuned -loss nweighted`
-????????????????????????????????
+`truenet fine_tune -i DatasetA/Training-pt -m ~/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/model_finetuned2 -l DatasetA/Training-pt -loss nweighted`
+
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -106,17 +106,17 @@ When running truenet it is necessary to use certain specific names and locations
 
 ### Examples
 
- - Run a segmentation on preprocessed data (from subject 1 in dataset A):
+ - Run a segmentation on preprocessed data (from subject 1 in dataset A). 
 
-`mkdir DatasetA/results-001`
+`mkdir DatasetA/results001`
 
-`truenet evaluate -i DatasetA/sub-001 -m /home/myname/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/results-001`
+`truenet evaluate -i DatasetA/sub001 -m /home/myname/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/results001`
 
- - Fine-tune an existing model using images and labels from XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+ - Fine-tune an existing model using images and labels in the same directory (named sub001_FLAIR.nii.gz, sub001_T1.nii.gz and sub001_manualmask.nii.gz, sub002_FLAIR.nii.gz, sub002_T1.nii.gz, sub002_manualmask.nii.gz, etc):
 
 `mkdir DatasetA/model_finetuned`
 
-`truenet fine_tune -i DatasetA/Training-pt -m ~/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/model_finetuned2 -l DatasetA/Training-pt -loss nweighted`
+`truenet fine_tune -i DatasetA/Training-pt -m ~/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/model_finetuned -l DatasetA/Training-pt -loss nweighted`
 
 
 ## Advanced usage

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ There are multiple options in how truenet can be used, but a simple summary is t
   
 ### Recommendations
 
-To begin with we recommend that you try one of the pretrained models that is supplied with truenet.  If you find that this doesn't work as well as you would like then try fine tuning one of the pretrained models.  If that still doesn't work well then try training from scratch.  
+To begin with we recommend that you try one of the pretrained models that is supplied with truenet (see [below](#pretrained-models)).  If you find that this doesn't work as well as you would like then try fine tuning one of the pretrained models.  If that still doesn't work well then try training from scratch.  
 
 Note that one reason that things might not work well is if the preprocessing fails, so make sure you check the preprocessing results before running trunet (looking at the images in _fsleyes_ is normally the best way to check if the registrations, brain extractions and bias field corrections are good or not).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ output_basename: name to be used for the processed FLAIR and T1 images (along wi
 output names are: output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and output_basename_WMmask.nii.gz will be saved
 ```
 **Example:**
-prepare_truenet_data ...
+
+`prepare_truenet_data FLAIR.nii.gz T1.nii.gz subject001`
 
 ## Simple usage
 
@@ -104,6 +105,13 @@ When running truenet it is necessary to use certain specific names and locations
    - where the *subject* part needs to be replaced with your subject identifier (e.g. sub-001)
 
 ### Examples
+
+ - Run a segmentation on preprocessed data (from subject 1 in dataset A):
+
+`truenet evaluate -i DatasetA/sub-001 -m /home/myname/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/results-001`
+
+ - Fine-tune an existing model using images and labels from XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXx
+
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you use TrUE-Net, please cite the following papers:
 ## Installation
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
-  - If you are not familiar with GitHub then the easiest way is to use the button labelled "<> Code" (right hand side, just above the file list) on the [main truenet page](/) and select the **Download ZIP** option. After you've done this, move the zip file to where you want to have truenet installed and unzip it.
+  - If you are not familiar with GitHub then the easiest way is to use the button labelled **<> Code** (right hand side, just above the file list) on the [main truenet page](/) and select the **Download ZIP** option. After you've done this, move the zip file to where you want to have truenet installed and unzip it.
 3. Run:
 ``` 
 python setup.py install

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This script performs the following steps:
  - T1-weighted images (or similar) need to be registered to the FLAIR (or whatever image was used to make the manual masks) using linear rigid-body registration (using FSL FLIRT).
  - creating a white matter mask, obtained from a dilated and inverted cortical CSF tissue segmentation (combined with other deep grey exclusion masks, using FSL FAST) and the _make bianca mask_ command in FSL BIANCA (Griffanti et al., 2016).
 
-#### prepare_truenet_data
+### prepare_truenet_data
 ```
 Usage: prepare_truenet_data <FLAIR_image_name> <T1_image_name> <output_basename>
  
@@ -69,7 +69,7 @@ prepare_truenet_data ...
 
 ## Simple usage
 
-#### Modes 
+### Modes 
 
 There are multiple options in how truenet can be used, but a simple summary is this:
  - to segment an image you use the _evaluate_ mode
@@ -79,7 +79,7 @@ There are multiple options in how truenet can be used, but a simple summary is t
  - alternatively, you can use a model that you or someone else has trained from scratch (using the _train_ mode of truenet)
  - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less of your own labelled data for training)
   
-#### Recommendations
+### Recommendations
 
 To begin with we recommend that you try one of the pretrained models that is supplied with truenet.  If you find that this doesn't work as well as you would like then try fine tuning one of the pretrained models.  If that still doesn't work well then try training from scratch.  
 
@@ -93,7 +93,7 @@ When performing a training from scratch, the situation is similar to that for fi
 
 
 
-#### Examples
+### Examples
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ prepare_truenet_data ...
 
 There are multiple options in how truenet can be used, but a simple summary is this:
  - to segment an image you use the _evaluate_ mode
-   - this requires an existing _model_ to be used, where a model is a deep learning network (which is what is inside truenet) that has been trained on some dataset
-   - you can use a _pretrained_ model that is supplied with truenet (see [below](#pretrained-models))
-    - to use any of these pretrained models, your images need to match relatively well to those used to train the model
-   - alternatively, you can use a model that you or someone else has trained from scratch (using the _train_ mode of truenet)
-   - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less of your own labelled data for training)
+ - this requires an existing _model_ to be used, where a model is a deep learning network (which is what is inside truenet) that has been trained on some dataset
+ - you can use a _pretrained_ model that is supplied with truenet (see [below](#pretrained-models))
+   - to use any of these pretrained models, your images need to match relatively well to those used to train the model
+ - alternatively, you can use a model that you or someone else has trained from scratch (using the _train_ mode of truenet)
+ - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less of your own labelled data for training)
   
 #### Recommendations
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And for options and inputs for each sub-command, type:
 truenet <subcommand> --help (e.g. truenet train --help)
 ```
 ## Preprocessing and preparing data for truenet
-T1-weighted and/or FLAIR images, or similar, can be used as inputs for truenet. A series of preprocessing operations need to be applied to the images. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
+T1-weighted and/or FLAIR images, or similar, can be used as inputs for truenet. A series of preprocessing operations needs to be applied to the images. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
 
 This script performs the following steps:
  - reorienting image to the standard MNI space (using FSL FLIRT)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you use TrUE-Net, please cite the following papers:
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
   - If you are not familiar with GitHub then the easiest way is to use the button labelled **<> Code** (right hand side, just above the file list) on the [main truenet page](/) and select the **Download ZIP** option. After you've done this, move the zip file to where you want to have truenet installed and unzip it.
-3. Run:
+3. Open up a terminal, go to the directory where you unzipped the file, and then run:
 ``` 
 python setup.py install
 ```

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To do this, once you download the models into a folder, please type the followin
 ```
 export TRUENET_PRETRAINED_MODEL_PATH="/absolute/path/to/the/model/folder"
 ```
-and then you can run truenet commands using the pretrained models as if they were integrated into FSL.
+and then you can run truenet commands using the pretrained models as if they were integrated into FSL. The export command needs to be done once for each terminal that you open, prior to running truenet.
 
 #### truenet evaluate: evaluating the TrUE-Net model, v1.0.1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Triplanar U-Net ensemble network (TrUE-Net) model 
+# Triplanar U-Net ensemble network (TrUE-Net) model
 
 ## DL tool for white matter hyperintensities segmentation
 
@@ -36,10 +36,10 @@ If you use TrUE-Net, please cite the following papers:
 
 ## Installation
 To install the truenet tool do the following:
-1. Clone the git repository into your local directory.  
+1. Clone the git repository into your local directory.
   - If you are not familiar with GitHub then the easiest way is to use the button labelled **<> Code** (right hand side, just above the file list) on the [main truenet page](/) and select the **Download ZIP** option. After you've done this, move the zip file to where you want to have truenet installed and unzip it.
 3. Open up a terminal, go to the directory where you unzipped the file, and then run:
-``` 
+```
 python setup.py install
 ```
 3. Use the instructions in this document ([simple usage](#simple-usage) is recommended for beginners)
@@ -56,7 +56,7 @@ truenet <subcommand> --help (e.g. truenet train --help)
 ---
 
 ## Preprocessing and preparing data for truenet
-T1-weighted and/or FLAIR images, or similar (e.g. T2-weighted images), can be used as inputs for truenet. A series of preprocessing operations needs to be applied to any image that you want to use truenet on. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
+T1-weighted and/or FLAIR images, or similar (e.g. T2-weighted images), can be used as inputs for truenet. A series of preprocessing operations needs to be applied to any image that you want to use truenet on. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_
 
 This script performs the following steps:
  - reorienting image to the standard MNI space (using FSL FLIRT)
@@ -68,11 +68,11 @@ This script performs the following steps:
 ### prepare_truenet_data
 ```
 Usage: prepare_truenet_data <FLAIR_image_name> <T1_image_name> <output_basename>
- 
+
 The script prepares the FLAIR and T1 data to be used in FSL truenet with a specified output basename
 FLAIR_image_name: name of the input unprocessed FLAIR image
 T1_image_name: name of the input unprocessed T1 image
-output_basename: name to be used for the processed FLAIR and T1 images (along with the absolute path); 
+output_basename: name to be used for the processed FLAIR and T1 images (along with the absolute path);
 
 output names are: output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and output_basename_WMmask.nii.gz will be saved
 ```
@@ -85,7 +85,7 @@ output names are: output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and ou
 
 ## Simple usage
 
-### Modes 
+### Modes
 
 There are multiple options in how truenet can be used, but a simple summary is this:
  - to segment an image you use the _evaluate_ mode
@@ -94,10 +94,10 @@ There are multiple options in how truenet can be used, but a simple summary is t
    - to use any of these pretrained models, your images need to match relatively well to those used to train the model
  - alternatively, you can use a model that you or someone else has trained from scratch (using the _train_ mode of truenet)
  - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less of your own labelled data for training)
-  
+
 ### Recommendations
 
-To begin with we recommend that you try one of the pretrained models that is supplied with truenet (see [below](#pretrained-models)).  If you find that this doesn't work as well as you would like then try fine tuning one of the pretrained models.  If that still doesn't work well then try training from scratch.  
+To begin with we recommend that you try one of the pretrained models that is supplied with truenet (see [below](#pretrained-models)).  If you find that this doesn't work as well as you would like then try fine tuning one of the pretrained models.  If that still doesn't work well then try training from scratch.
 
 Note that one reason that things might not work well is if the preprocessing fails, so make sure you check the preprocessing results before running trunet (looking at the images in _fsleyes_ is normally the best way to check if the registrations, brain extractions and bias field corrections are good or not).
 
@@ -105,7 +105,7 @@ The simplest way to choose which pretrained model to choose is just by looking a
 
 When performing a fine tuning operation it is necessary to supply your own labelled images (i.e. images and manual segmentations) and for this to work we recommend that you have at least NNNN images (though you can try with less and see if you are lucky). Typically, the more you have the better your chances of it adapting well to the characteristics of your images and/or the specifics of your segmentation protocol/preferences. Normally we would recommend trying fine tuning before training from scratch (and the latter isn't needed if your fine tuning results are good) but the one exception to this is when your images are obviously very different to those in the pretrained datasets, as in this case you are unlikely to get a good result from fine tuning.
 
-When performing a training from scratch, the situation is similar to that for fine tuning - you need a set of your own labelled images, but you need more in this case and we would recommend a minimum of NNNN images (though again, you can try your luck with less). 
+When performing a training from scratch, the situation is similar to that for fine tuning - you need a set of your own labelled images, but you need more in this case and we would recommend a minimum of NNNN images (though again, you can try your luck with less).
 
 ### Naming conventions
 
@@ -120,7 +120,7 @@ When running truenet it is necessary to use certain specific names and locations
 
 ### Examples
 
- - Run a segmentation on preprocessed data (from subject 1 in dataset A, stored in directory DatasetA/sub001 and containing files names sub001_T1.nii.gz and sub001_FLAIR.nii.gz, as created by `prepare_truenet_data`). 
+ - Run a segmentation on preprocessed data (from subject 1 in dataset A, stored in directory DatasetA/sub001 and containing files names sub001_T1.nii.gz and sub001_FLAIR.nii.gz, as created by `prepare_truenet_data`).
 
 `mkdir DatasetA/results001`
 
@@ -157,12 +157,12 @@ Details of the different commands and their options are available through the co
 
 Triplanar ensemble U-Net model, v1.0.1
 
-```  
+```
 Subcommands available:
-    - truenet evaluate      Applying a saved/pretrained TrUE-Net model for testing
-    - truenet fine_tune     Fine-tuning a saved/pretrained TrUE-Net model from scratch
-    - truenet train         Training a TrUE-Net model from scratch
-    - truenet loo_validate  Leave-one-out validation of TrUE-Net model
+    - truenet evaluate        Applying a saved/pretrained TrUE-Net model for testing
+    - truenet fine_tune       Fine-tuning a saved/pretrained TrUE-Net model from scratch
+    - truenet train           Training a TrUE-Net model from scratch
+    - truenet cross_validate  Leave-one-out validation of TrUE-Net model
 ```
 
 ### Applying the TrUE-Net model (performing segmentation)
@@ -172,9 +172,9 @@ Subcommands available:
  - Currently pretrained models, based on the [MWSC](linkhere) (MICCAI WMH Segmentation Challenge) and [UKBB](linkhere) (UK Biobank) datasets, are available at: https://drive.google.com/drive/folders/1iqO-hd27NSHHfKun125Rt-2fh1l9EiuT?usp=share_link
 
  - These will be integrated more fully into FSL in the future, where these models will be available in the '$FSLDIR/data/truenet/Models' folder.
- 
- - Currently, for testing purposes, you can download the models from the above drive link and place them into a folder of your choice. You then need to set the folder as an environment variable before running truenet. 
-To do this, once you download the models into a folder, please type the following in the command prompt: 
+
+ - Currently, for testing purposes, you can download the models from the above drive link and place them into a folder of your choice. You then need to set the folder as an environment variable before running truenet.
+To do this, once you download the models into a folder, please type the following in the command prompt:
 ```
 export TRUENET_PRETRAINED_MODEL_PATH="/absolute/path/to/the/model/folder"
 ```
@@ -184,12 +184,12 @@ and then you can run truenet commands using the pretrained models as if they wer
 
 ```
 Usage: truenet evaluate -i <input_directory> -m <model_directory> -o <output_directory> [options]
-   
+
 Compulsory arguments:
        -i, --inp_dir                         Path to the directory containing FLAIR and T1 images for testing
-       -m, --model_name                      Model basename with absolute path (will not be considered if optional argument -p=True)                                                                  
+       -m, --model_name                      Model basename with absolute path (will not be considered if optional argument -p=True)
        -o, --output_dir                      Path to the directory for saving output predictions
-   
+
 Optional arguments:
        -p, --pretrained_model                Whether to use a pre-trained model, if selected True, -m (compulsory argument will not be onsidered) [default = False]
        -pmodel, --pretrained_model_name      Pre-trained model to be used: mwsc, ukbb [default = mwsc]
@@ -217,22 +217,22 @@ Usage: truenet fine_tune -i <input_directory> -l <label_directory> -m <model_dir
 
 Compulsory arguments:
        -i, --inp_dir                         Path to the directory containing FLAIR and T1 images for fine-tuning
-       -l, --label_dir                       Path to the directory containing manual labels for training 
+       -l, --label_dir                       Path to the directory containing manual labels for training
        -m, --model_dir                       Path to the directory where the trained model/weights were saved
        -o, --output_dir                      Path to the directory where the fine-tuned model/weights need to be saved
-   
+
 Optional arguments:
        -p, --pretrained_model                Whether to use a pre-trained model, if selected True, -m (compulsory argument will not be considered) [default = False]
        -pmodel, --pretrained_model_name      Pre-trained model to be used: mwsc, ukbb [default = mwsc]
        -cpld_type, --cp_load_type            Checkpoint to be loaded. Options: best, last, everyN [default = last]
        -cpld_n, --cpload_everyn_N            If everyN option was chosen for loading a checkpoint, the N value [default = 10]
-       -ftlayers, --ft_layers                Layers to fine-tune starting from the decoder (e.g. 1 2 -> final two two decoder layers, refer to the figure above) 
+       -ftlayers, --ft_layers                Layers to fine-tune starting from the decoder (e.g. 1 2 -> final two two decoder layers, refer to the figure above)
        -tr_prop, --train_prop                Proportion of data used for fine-tuning [0, 1]. The rest will be used for validation [default = 0.8]
        -bfactor, --batch_factor              Number of subjects to be considered for each mini-epoch [default = 10]
        -loss, --loss_function                Applying spatial weights to loss function. Options: weighted, nweighted [default=weighted]
        -gdir, --gmdist_dir                   Directory containing GM distance map images. Required if -loss = weighted [default = None]
        -vdir, --ventdist_dir                 Directory containing ventricle distance map images. Required if -loss = weighted [default = None]
-       -nclass, --num_classes                Number of classes to consider in the target labels (nclass=2 will consider only 0 and 1 in labels; 
+       -nclass, --num_classes                Number of classes to consider in the target labels (nclass=2 will consider only 0 and 1 in labels;
                                              any additional class will be considered part of background class [default = 2]
        -plane, --acq_plane                   The plane in which the model needs to be fine-tuned. Options: axial, sagittal, coronal, all [default  all]
        -da, --data_augmentation              Applying data augmentation [default = True]
@@ -257,14 +257,14 @@ Optional arguments:
 #### truenet train: training the TrUE-Net model from scratch, v1.0.1
 
 ```
-Usage: truenet train -i <input_directory> -l <label_directory> -m <model_directory> [options] 
+Usage: truenet train -i <input_directory> -l <label_directory> -m <model_directory> [options]
 
 
 Compulsory arguments:
-       -i, --inp_dir                 Path to the directory containing FLAIR and T1 images for training 
-       -l, --label_dir               Path to the directory containing manual labels for training 
-       -m, --model_dir               Path to the directory where the training model or weights need to be saved 
-   
+       -i, --inp_dir                 Path to the directory containing FLAIR and T1 images for training
+       -l, --label_dir               Path to the directory containing manual labels for training
+       -m, --model_dir               Path to the directory where the training model or weights need to be saved
+
 Optional arguments:
        -tr_prop, --train_prop        Proportion of data used for training [0, 1]. The rest will be used for validation [default = 0.8]
        -bfactor, --batch_factor      Number of subjects to be considered for each mini-epoch [default = 10]
@@ -293,19 +293,19 @@ Optional arguments:
 
 ### Cross-validation of TrUE-Net model
 
-#### truenet cross_validate: cross-validation of the TrUE-Net model, v1.0.1  
-   
+#### truenet cross_validate: cross-validation of the TrUE-Net model, v1.0.1
+
 ```
 Usage: truenet cross_validate -i <input_directory> -l <label_directory> -o <output_directory> [options]
-   
+
 Compulsory arguments:
        -i, --inp_dir                         Path to the directory containing FLAIR and T1 images for fine-tuning
-       -l, --label_dir                       Path to the directory containing manual labels for training 
+       -l, --label_dir                       Path to the directory containing manual labels for training
        -o, --output_dir                      Path to the directory for saving output predictions
-   
+
 Optional arguments:
        -fold, --cv_fold                      Number of folds for cross-validation (default = 5)
-       -resume_fold, --resume_from_fold      Resume cross-validation from the specified fold (default = 1)         
+       -resume_fold, --resume_from_fold      Resume cross-validation from the specified fold (default = 1)
        -tr_prop, --train_prop                Proportion of data used for training [0, 1]. The rest will be used for validation [default = 0.8]
        -bfactor, --batch_factor              Number of subjects to be considered for each mini-epoch [default = 10]
        -loss, --loss_function                Applying spatial weights to loss function. Options: weighted, nweighted [default=weighted]
@@ -324,7 +324,7 @@ Optional arguments:
        -bs, --batch_size                     Batch size used for fine-tuning [default = 8]
        -ep, --num_epochs                     Number of epochs for fine-tuning [default = 60]
        -es, --early_stop_val                 Number of fine-tuning epochs to wait for progress (early stopping) [default = 20]
-       -int, --intermediate                  Saving intermediate prediction results (individual planes) for each subject [default = False]                                                                                  
+       -int, --intermediate                  Saving intermediate prediction results (individual planes) for each subject [default = False]
        -v, --verbose                         Display debug messages [default = False]
        -h, --help.                           Print help message
 ```
@@ -346,8 +346,3 @@ We used a weighted sum of the voxel-wise cross-entropy loss function and the Dic
        width=600
        />
 </p>
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you use TrUE-Net, please cite the following papers:
 ## Installation
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
-  - If you are not familiar with GitHub then the easiest way is to use the Clone button (top, right hand side) on the [main truenet page](..) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
+  - If you are not familiar with GitHub then the easiest way is to use the Clone button (top, right hand side) on the [main truenet page](master) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
 3. Run:
 ``` 
 python setup.py install

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install the truenet tool do the following:
 python setup.py install
 ```
 3. Use the instructions in this document ([simple usage](#simple-usage) is recommended for beginners)
-4. More detailed lists of options for the subcommands are available in the command-line help:
+4. For more advanced usage, detailed lists of options for the subcommands are available in the command-line help:
 ```
 truenet --help
 ```
@@ -64,18 +64,36 @@ T1_image_name 	name of the input unprocessed T1 image
 output_basename 	name to be used for the processed FLAIR and T1 images (along with the absolute path); 
                      output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and output_basename_WMmask.nii.gz will be saved
 ```
+**Example:**
+prepare_truenet_data ...
 
 ## Simple usage
 
+#### Options 
+
 There are multiple options in how truenet can be used, but a simple summary is this:
  - to segment an image you use the _evaluate_ mode
-   - this requires an existing _model_ to be used, where a model is a network that has been trained on some dataset
+   - this requires an existing _model_ to be used, where a model is a deep learning network (which is what is inside truenet) that has been trained on some dataset
    - you can use a _pretrained_ model that is supplied with truenet (see [below](#pretrained-models))
-    - to use any of these pretrained models your images need to match relatively well to those used to train the model
+    - to use any of these pretrained models, your images need to match relatively well to those used to train the model
    - alternatively, you can use a model that you or someone else has trained from scratch (using the _train_ mode of truenet)
-   - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less data for training)
+   - another alternative is to take a pretrained model and _fine tune_ this on your data, which is more efficient than training from scratch (that is, it requires less of your own labelled data for training)
+  
+#### Recommendations
 
-### Examples
+To begin with we recommend that you try one of the pretrained models that is supplied with truenet.  If you find that this doesn't work as well as you would like then try fine tuning one of the pretrained models.  If that still doesn't work well then try training from scratch.  
+
+Note that one reason that things might not work well is if the preprocessing fails, so make sure you check the preprocessing results before running trunet (looking at the images in _fsleyes_ is normally the best way to check if the registrations, brain extractions and bias field corrections are good or not).
+
+The simplest way to choose which pretrained model to choose is just by looking at example images from those datasets (see HERE?!?!?) and deciding which ones look closer to yours or not.  One of the reasons that different models are needed is that images vary between different MRI sequences and scanners.  Sometimes the differences are obvious to the eye and sometimes not, and deep learning networks can sometimes be sensitive to subtle differences.  If you are not sure which is closest then pick one and try it, and then try the other one if you are not happy.
+
+When performing a fine tuning operation it is necessary to supply your own labelled images (i.e. images and manual segmentations) and for this to work we recommend that you have at least NNNN images (though you can try with less and see if you are lucky). Typically, the more you have the better your chances of it adapting well to the characteristics of your images and/or the specifics of your segmentation protocol/preferences. Normally we would recommend trying fine tuning before training from scratch (and the latter isn't needed if your fine tuning results are good) but the one exception to this is when your images are obviously very different to those in the pretrained datasets, as in this case you are unlikely to get a good result from fine tuning.
+
+When performing a training from scratch, the situation is similar to that for fine tuning - you need a set of your own labelled images, but you need more in this case and we would recommend a minimum of NNNN images (though again, you can try your luck with less). 
+
+
+
+#### Examples
 
 ## Advanced usage
 
@@ -97,7 +115,7 @@ Subcommands available:
 
 #### Pretrained models
 
- - Currently pretrained models, based on the [MWSC](linkhere) and UKBB [UK Biobank](linkhere) datasets, are available at: https://drive.google.com/drive/folders/1iqO-hd27NSHHfKun125Rt-2fh1l9EiuT?usp=share_link
+ - Currently pretrained models, based on the [MWSC](linkhere) (MICCAI WMH Segmentation Challenge) and [UKBB](linkhere) (UK Biobank) datasets, are available at: https://drive.google.com/drive/folders/1iqO-hd27NSHHfKun125Rt-2fh1l9EiuT?usp=share_link
 
  - These will be integrated more fully into FSL in the future, where these models will be available in the '$FSLDIR/data/truenet/Models' folder.
  

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
  - [advanced usage](#advanced-usage)
  - [technical details](#technical-details)
 
+---
+---
+
 ## Citation
 
 If you use TrUE-Net, please cite the following papers:
@@ -18,6 +21,8 @@ If you use TrUE-Net, please cite the following papers:
 - Sundaresan, V., Zamboni, G., Rothwell, P.M., Jenkinson, M. and Griffanti, L., 2021. Triplanar ensemble U-Net model for white matter hyperintensities segmentation on MR images. Medical Image Analysis, p.102184. [DOI: https://doi.org/10.1016/j.media.2021.102184] (preprint available at https://doi.org/10.1101/2020.07.24.219485)
 - Sundaresan, V., Zamboni, G., Dinsdale, N. K., Rothwell, P. M., Griffanti, L., & Jenkinson, M. (2021). Comparison of domain adaptation techniques for white matter hyperintensity segmentation in brain MR images. bioRxiv. [DOI: https://doi.org/10.1101/2021.03.12.435171] (accepted in Medical Image Analysis, DOI to be updated soon).
 
+---
+---
 
 ## Dependencies
 - Main truenet dependencies:
@@ -26,6 +31,8 @@ If you use TrUE-Net, please cite the following papers:
 - Extra dependencies for pre-processing:
   - FMRIB software library (FSL) 6.0
 
+---
+---
 
 ## Installation
 To install the truenet tool do the following:
@@ -44,6 +51,10 @@ And for options and inputs for each sub-command, type:
 ```
 truenet <subcommand> --help (e.g. truenet train --help)
 ```
+
+---
+---
+
 ## Preprocessing and preparing data for truenet
 T1-weighted and/or FLAIR images, or similar (e.g. T2-weighted images), can be used as inputs for truenet. A series of preprocessing operations needs to be applied to any image that you want to use truenet on. A script for performing these preprocessing steps has been provided: _prepare_truenet_data_ 
 
@@ -68,6 +79,9 @@ output names are: output_basename_FLAIR.nii.gz, output_basename_T1.nii.gz and ou
 **Example:**
 
 `prepare_truenet_data FLAIR.nii.gz T1.nii.gz sub001`
+
+---
+---
 
 ## Simple usage
 
@@ -110,16 +124,30 @@ When running truenet it is necessary to use certain specific names and locations
 
 `mkdir DatasetA/results001`
 
-`truenet evaluate -i DatasetA/sub001 -m /home/myname/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/results001`
+`truenet evaluate -i DatasetA/sub001 -m /home/yourname/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/results001`
 
- - Fine-tune an existing model using images and labels in the same directory (named sub001_FLAIR.nii.gz, sub001_T1.nii.gz and sub001_manualmask.nii.gz, sub002_FLAIR.nii.gz, sub002_T1.nii.gz, sub002_manualmask.nii.gz, etc):
+---
+
+ - Fine-tune an existing model using images and labels in the same directory (named sub001_FLAIR.nii.gz, sub001_T1.nii.gz and sub001_manualmask.nii.gz, sub002_FLAIR.nii.gz, sub002_T1.nii.gz, sub002_manualmask.nii.gz, etc.):
 
 `mkdir DatasetA/model_finetuned`
 
-`truenet fine_tune -i DatasetA/Training-pt -m ~/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/model_finetuned -l DatasetA/Training-pt -loss nweighted`
+`truenet fine_tune -i DatasetA/Training-partial -m ~/truenet-master/truenet/pretrained_models/mwsc/MWSC_FLAIR_T1/Truenet_MWSC_FLAIR_T1 -o DatasetA/model_finetuned -l DatasetA/Training-partial -loss nweighted`
 
- - Training a model from scratch
+    - then apply this model to a new subject:
 
+`truenet evaluate -i DatasetA/newsub -m DatasetA/model_finetuned/Truenet_model_weights_beforeES -o DatasetA/newresults`
+
+---
+
+ - Training a model from scratch using images and labels in the same directory (named sub001_FLAIR.nii.gz, sub001_T1.nii.gz and sub001_manualmask.nii.gz, sub002_FLAIR.nii.gz, sub002_T1.nii.gz, sub002_manualmask.nii.gz, etc.):
+
+`mkdir DatasetA/model`
+
+`truenet train -i DatasetA/Training-full -l DatasetA/Training-full -m DatasetA/model -loss nweighted`
+
+---
+---
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you use TrUE-Net, please cite the following papers:
 ## Installation
 To install the truenet tool do the following:
 1. Clone the git repository into your local directory.  
-  - If you are not familiar with GitHub then the easiest way is to use the Clone button and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
+  - If you are not familiar with GitHub then the easiest way is to use the Clone button (top, right hand side) on the [main truenet page](..) and select the zip file option for download, then move the zip file to where you want to have truenet installed and unzip it.
 3. Run:
 ``` 
 python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-nibabel>=2.*
+nibabel
 scipy
 torch
 numpy
 scikit-image
-

--- a/truenet/scripts/prepare_truenet_data
+++ b/truenet/scripts/prepare_truenet_data
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #   Copyright (C) 2021 University of Oxford
 #   SHCOPYRIGHT
 #set -e
@@ -51,7 +51,7 @@ $FSLDIR/bin/fslreorient2std ${t1file}.nii.gz ${TMPVISDIR}/T1.nii.gz
 
 # PREPROCESSING OF FLAIR IMAGE
 $FSLDIR/bin/bet ${TMPVISDIR}/FLAIR.nii.gz ${TMPVISDIR}/FLAIR_brain.nii.gz
-$FSLDIR/bin/fast -B --nopve ${TMPVISDIR}/FLAIR_brain.nii.gz 
+$FSLDIR/bin/fast -B --nopve ${TMPVISDIR}/FLAIR_brain.nii.gz
 ${FSLDIR}/bin/imcp ${TMPVISDIR}/FLAIR_brain_restore.nii.gz ${outdir}/${outname}_FLAIR.nii.gz
 
 # APPLYING FSL_ANAT ON THE REORIENTED T1 IMAGE
@@ -65,21 +65,7 @@ $FSLDIR/bin/make_bianca_mask ${TMPVISDIR}/T1.anat/T1_biascorr ${TMPVISDIR}/T1.an
 $FSLDIR/bin/flirt -dof 6 -in ${TMPVISDIR}/T1.anat/T1_biascorr_bianca_mask.nii.gz -ref ${TMPVISDIR}/FLAIR_brain.nii.gz -applyxfm -init ${TMPVISDIR}/${outname}_T1_2FLAIR.mat -out ${TMPVISDIR}/${outname}_WMmask.nii.gz
 $FSLDIR/bin/fslmaths ${TMPVISDIR}/${outname}_WMmask.nii.gz -thr 0.5 -bin ${outdir}/${outname}_WMmask.nii.gz
 
-# REMOVES TEMPORARY DIRECTORY 
+# REMOVES TEMPORARY DIRECTORY
 rm -r ${TMPVISDIR}
 
 exit 0
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/truenet/scripts/prepare_truenet_data
+++ b/truenet/scripts/prepare_truenet_data
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #   Copyright (C) 2021 University of Oxford
 #   SHCOPYRIGHT
 #set -e

--- a/truenet/scripts/truenet
+++ b/truenet/scripts/truenet
@@ -1,4 +1,4 @@
-#!/usr/bin/env fslpython
+#!/usr/bin/env python
 import argparse
 import sys
 import pkg_resources
@@ -161,6 +161,3 @@ if __name__ == "__main__":
     else:
         parser.parse_args(["--help"])
         sys.exit(0)
-
-
-

--- a/truenet/true_net/truenet_data_postprocessing.py
+++ b/truenet/true_net/truenet_data_postprocessing.py
@@ -24,7 +24,7 @@ def resize_to_original_size(probs, testpathdicts, plane='axial'):
     st = 0    
     testpath = testpathdicts[0]
     flair_path = testpath['flair_path']
-    data = nib.load(flair_path).get_data().astype(float)
+    data = nib.load(flair_path).get_fdata()
     _,coords = truenet_data_preprocessing.tight_crop_data(data)
     if plane =='axial':
         probs_sub = probs[st:st+coords[5],:,:,:]
@@ -60,7 +60,7 @@ def get_final_3dvolumes(volume3d,testpathdicts):
     st = 0
     testpath = testpathdicts[0]
     flair_path = testpath['flair_path']
-    data = nib.load(flair_path).get_data().astype(float)
+    data = nib.load(flair_path).get_fdata()
     volume3d = 0 * data
     _,coords = truenet_data_preprocessing.tight_crop_data(data)
     row_cent = coords[1]//2 + coords[0]

--- a/truenet/true_net/truenet_data_preparation.py
+++ b/truenet/true_net/truenet_data_preparation.py
@@ -91,12 +91,12 @@ def load_and_crop_data(data_path, weighted=True):
     flair_path = data_path['flair_path']
     t1_path = data_path['t1_path']
     lab_path = data_path['gt_path']
-    
-    data_sub_org = nib.load(flair_path).get_data().astype(float)
-    data_t1_sub_org = nib.load(t1_path).get_data().astype(float)    
-    labels_sub = nib.load(lab_path).get_data().astype(float) 
+
+    data_sub_org = nib.load(flair_path).get_fdata()
+    data_t1_sub_org = nib.load(t1_path).get_fdata()
+    labels_sub = nib.load(lab_path).get_fdata()
     labels_sub[labels_sub>1.5] = 0
-         
+
     _,coords = truenet_data_preprocessing.tight_crop_data(data_sub_org)
     row_cent = coords[1]//2 + coords[0]
     rowstart = np.amax([row_cent-64,0])
@@ -125,8 +125,8 @@ def load_and_crop_data(data_path, weighted=True):
     if weighted:
         gmdist_path = data_path['gmdist_path']
         ventdist_path = data_path['ventdist_path']
-        GM_distance_sub = nib.load(gmdist_path).get_data().astype(float) 
-        ventdistmap_sub = nib.load(ventdist_path).get_data().astype(float)
+        GM_distance_sub = nib.load(gmdist_path).get_fdata()
+        ventdistmap_sub = nib.load(ventdist_path).get_fdata()
         GM_distance_sub1 = np.zeros([128,coords[3],coords[5]])
         ventdistmap_sub1 = np.zeros([128,coords[3],coords[5]])
         GM_distance_sub_piece = GM_distance_sub[rowstart:rowend,colstart:colend,stackstart:stackend]
@@ -309,10 +309,10 @@ def load_and_crop_test_data(data_path):
     '''
     flair_path = data_path['flair_path']
     t1_path = data_path['t1_path']
-    
-    data_sub_org = nib.load(flair_path).get_data().astype(float)
-    data_t1_sub_org = nib.load(t1_path).get_data().astype(float)  
-         
+
+    data_sub_org = nib.load(flair_path).get_fdata()
+    data_t1_sub_org = nib.load(t1_path).get_fdata()
+
     _,coords = truenet_data_preprocessing.tight_crop_data(data_sub_org)
     row_cent = coords[1]//2 + coords[0]
     rowstart = np.amax([row_cent-64,0])

--- a/truenet/true_net/truenet_train.py
+++ b/truenet/true_net/truenet_train.py
@@ -253,7 +253,7 @@ def train_truenet(train_name_dicts, val_names_dicts, model, criterion, optimizer
 
         if save_checkpoint:
             np.savez(os.path.join(dir_checkpoint,'losses_' + mode + '.npz'), train_loss=losses_train, val_loss=losses_val)
-            np.savez(os.path.join(dir_checkpoint,'validation_dice_' + mode + '.npz'), dice_val=dice_val)
+            np.savez(os.path.join(dir_checkpoint,'validation_dice_' + mode + '.npz'), dice_val=dice_val[0].detach().cpu().numpy())
         
         early_stopping(val_av_loss, val_av_dice, best_val_dice, model, epoch, optimizer, scheduler, av_loss, 
                        train_params, weights=save_weights, checkpoint=save_checkpoint, save_condition=save_case, 

--- a/truenet/true_net/truenet_train.py
+++ b/truenet/true_net/truenet_train.py
@@ -28,7 +28,7 @@ def dice_coeff(inp, tar):
     target_vect = tar.contiguous().view(-1)
     intersection = (pred_vect * target_vect).sum()
     dice = (2. * intersection + smooth) / (torch.sum(pred_vect) + torch.sum(target_vect) + smooth)
-    return dice
+    return dice.cpu()
 
 def validate_truenet(val_dataloader, model, batch_size, device, criterion, weighted=True, verbose=False):
     '''
@@ -83,8 +83,8 @@ def validate_truenet(val_dataloader, model, batch_size, device, criterion, weigh
                 dice_val = dice_coeff(mask_vector, target_vector)
                 
                 dice_values += dice_val
-    val_av_loss = (running_val_loss / val_batch_count)#.cpu().numpy()
-    val_dice = (dice_values / val_batch_count)#.detach().cpu().numpy()
+    val_av_loss = (running_val_loss / val_batch_count)
+    val_dice = (dice_values / val_batch_count)
     print('Validation set: Average loss: ',  val_av_loss, flush=True)
     print('Validation set: Average accuracy: ',  val_dice, flush=True)
     return val_av_loss, val_dice


### PR DESCRIPTION
Hi @v-sundaresan, this PR contains a few small fixes to the truenet code:
  - Pip has become stricter w.r.t. formatting of dependency specifcations - `nibabel>=2.*` is now invalid syntax, so the easiest option is to leave nibabel unpinned
  - The nibabel `Nifti1Image.get_data` method no longer works as of nibabel 5 - you need to use  `get_fdata` instead
  - Small typo in the README
  - Make sure that the outputs o `truenet_train.dice_coeff` are in CPU memory