### PR TITLE
Do not fix LR axis size at 128 voxels

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Optional arguments:
 
 <p align="center">
        <img
-       src="structural/fine_tuning_images.png"
+       src="images/fine_tuning_images.png"
        alt="Layers for fine-tuning truenet model."
        width=400
        />
@@ -376,16 +376,18 @@ Optional arguments:
 ## Technical Details
 
 ### TrUE-Net architecture:
+
 <img
-src="structural/main_architecture_final.png"
+src="images/main_architecture_final.png"
 alt="Triplanar U-Net ensemble network (TrUE-Net). (a) U-Net model used in individual planes, (b) Overall TrUE-Net architecture."
 />
 
 ### Applying spatial weights in the loss function:
 We used a weighted sum of the voxel-wise cross-entropy loss function and the Dice loss as the total cost function. We weighted the CE loss function using a spatial weight map (a sample shown in the figure) to up-weight the areas that are more likely to contain the less represented class (i.e. WMHs).
+
 <p align="center">
        <img
-       src="structural/spatial_weight_map.png"
+       src="images/spatial_weight_map.png"
        alt="Spatial weight maps to be applied in the truenet loss function."
        width=600
        />

--- a/truenet/true_net/truenet_data_postprocessing.py
+++ b/truenet/true_net/truenet_data_postprocessing.py
@@ -17,27 +17,26 @@ def resize_to_original_size(probs, ref_image_path, plane='axial'):
     :return: 3D probability maps with cropped dimensions.
     '''
     overall_prob = np.array([])
-    st = 0
     data = nib.load(ref_image_path).get_fdata()
     _,coords = truenet_data_preprocessing.tight_crop_data(data)
     if plane =='axial':
-        probs_sub = probs[st:st+coords[5],:,:,:]
+        probs_sub = probs[:coords[5],:,:,:]
         prob_specific_sub = np.zeros([probs_sub.shape[0],probs_sub.shape[1],coords[3]])
         for sli in range(probs_sub.shape[0]):
             prob_specific_sub[sli,:,:] = resize(probs_sub[sli,:,:,1], [probs_sub.shape[1], coords[3]], preserve_range=True)
         overall_prob = np.concatenate((overall_prob,prob_specific_sub),axis = 0) if overall_prob.size else prob_specific_sub
     elif plane == 'sagittal':
-        probs_sub = probs[:128,:,:,:]
+        probs_sub = probs[:coords[1],:,:,:]
         probs_sub_resize = np.zeros([probs_sub.shape[0],coords[3],coords[5]])
         for sli in range(probs_sub.shape[0]):
             probs_sub_resize[sli,:,:] = resize(probs_sub[sli,:,:,1], [coords[3], coords[5]], preserve_range=True)
         prob_specific_sub = probs_sub_resize.transpose(2,0,1)
         overall_prob = np.concatenate((overall_prob,prob_specific_sub),axis = 0) if overall_prob.size else prob_specific_sub
     elif plane == 'coronal':
-        probs_sub = probs[st:st+coords[3],:,:,:]
-        probs_sub_resize = np.zeros([probs_sub.shape[0],128,coords[5]])
+        probs_sub = probs[:coords[3],:,:,:]
+        probs_sub_resize = np.zeros([probs_sub.shape[0],coords[1],coords[5]])
         for sli in range(probs_sub.shape[0]):
-            probs_sub_resize[sli,:,:] = resize(probs_sub[sli,:,:,1], [128, coords[5]], preserve_range=True)
+            probs_sub_resize[sli,:,:] = resize(probs_sub[sli,:,:,1], [coords[1], coords[5]], preserve_range=True)
         prob_specific_sub = probs_sub_resize.transpose(2,1,0)
         overall_prob = np.concatenate((overall_prob,prob_specific_sub),axis = 0) if overall_prob.size else prob_specific_sub
     return overall_prob
@@ -51,18 +50,18 @@ def get_final_3dvolumes(volume3d, ref_image_path):
     '''
     volume3d = np.tile(volume3d,(1,1,1,1))
     volume4d = volume3d.transpose(1,2,3,0)
-    st = 0
     data = nib.load(ref_image_path).get_fdata()
     volume3d = 0 * data
     _,coords = truenet_data_preprocessing.tight_crop_data(data)
-    row_cent = coords[1]//2 + coords[0]
-    rowstart = np.amax([row_cent-64,0])
-    rowend = np.amin([row_cent+64,data.shape[0]])
-    colstart = coords[2]
-    colend = coords[2] + coords[3]
+    rowstart   = coords[0]
+    rowend     = coords[0] + coords[1]
+    colstart   = coords[2]
+    colend     = coords[2] + coords[3]
     stackstart = coords[4]
-    stackend = coords[4] + coords[5]
+    stackend   = coords[4] + coords[5]
     data_sub = data[rowstart:rowend,colstart:colend,stackstart:stackend]
-    required_stacks = volume4d[st:st+data_sub.shape[2],:data_sub.shape[0],:data_sub.shape[1],0].transpose(1,2,0)
+    required_stacks = volume4d[:data_sub.shape[2],
+                               :data_sub.shape[0],
+                               :data_sub.shape[1],0].transpose(1,2,0)
     volume3d[rowstart:rowend,colstart:colend,stackstart:stackend] = required_stacks
     return volume3d

--- a/truenet/true_net/truenet_data_postprocessing.py
+++ b/truenet/true_net/truenet_data_postprocessing.py
@@ -21,9 +21,9 @@ def resize_to_original_size(probs, ref_image_path, plane='axial'):
     _,coords = truenet_data_preprocessing.tight_crop_data(data)
     if plane =='axial':
         probs_sub = probs[:coords[5],:,:,:]
-        prob_specific_sub = np.zeros([probs_sub.shape[0],probs_sub.shape[1],coords[3]])
+        prob_specific_sub = np.zeros([probs_sub.shape[0],coords[1],coords[3]])
         for sli in range(probs_sub.shape[0]):
-            prob_specific_sub[sli,:,:] = resize(probs_sub[sli,:,:,1], [probs_sub.shape[1], coords[3]], preserve_range=True)
+            prob_specific_sub[sli,:,:] = resize(probs_sub[sli,:,:,1], [coords[1], coords[3]], preserve_range=True)
         overall_prob = np.concatenate((overall_prob,prob_specific_sub),axis = 0) if overall_prob.size else prob_specific_sub
     elif plane == 'sagittal':
         probs_sub = probs[:coords[1],:,:,:]

--- a/truenet/true_net/truenet_data_preparation.py
+++ b/truenet/true_net/truenet_data_preparation.py
@@ -17,8 +17,8 @@ def create_data_array(names, is_weighted=True, plane='axial'):
     :param plane: acquisition plane
     :return: dictionary of input arrays
     '''
-    data        = np.array([])
-    data_t1     = np.array([])
+    data        = None
+    data_t1     = None
     labels      = np.array([])
     GM_distance = np.array([])
     ventdistmap = np.array([])
@@ -65,13 +65,13 @@ def create_data_array(names, is_weighted=True, plane='axial'):
             GM_distance = append(GM_distance, GM_distance_sub1)
             ventdistmap = append(ventdistmap, ventdistmap_sub1)
 
-    if data.size:
+    if data is not None and data.size:
         data = np.tile(data,(1,1,1,1))
         data = data.transpose(1,2,3,0)
     else:
         data = None
 
-    if data_t1.size:
+    if data is not None and data_t1.size:
         data_t1 = np.tile(data_t1,(1,1,1,1))
         data_t1 = data_t1.transpose(1,2,3,0)
     else:
@@ -359,8 +359,8 @@ def create_test_data_array(names, plane='axial'):
     :param plane: acquisition plane
     :return: input array
     '''
-    data    = np.array([])
-    data_t1 = np.array([])
+    data    = None
+    data_t1 = None
 
     def append(dest, arr):
 

--- a/truenet/true_net/truenet_data_preparation.py
+++ b/truenet/true_net/truenet_data_preparation.py
@@ -17,88 +17,72 @@ def create_data_array(names, is_weighted=True, plane='axial'):
     :param plane: acquisition plane
     :return: dictionary of input arrays
     '''
-    data = np.array([])
-    data_t1 = np.array([])
-    labels = np.array([])
+    data        = np.array([])
+    data_t1     = np.array([])
+    labels      = np.array([])
     GM_distance = np.array([])
     ventdistmap = np.array([])
 
+    def append(dest, arr, binarise=False):
+        if plane == 'axial':
+            arr   = arr.transpose(2, 0, 1)
+            shape = [arr.shape[0], 128, 192]
+        elif plane == 'sagittal':
+            shape = [arr.shape[0], 192, 120]
+        elif plane == 'coronal':
+            arr   = arr.transpose(1, 0, 2)
+            shape = [arr.shape[0], 128, 80]
+
+        arr = resize(arr, shape, preserve_range=True)
+
+        if binarise:
+            arr = (arr > 0.5).astype(float)
+
+        if dest is not None and dest.size:
+            return np.concatenate((dest, arr), axis=0)
+        else:
+            return arr
+
     for i in range(len(names)):
         array_loaded = load_and_crop_data(names[i], weighted=is_weighted)
-        data_sub1 = array_loaded['data_cropped']
+        data_sub1    = array_loaded['data_cropped']
         data_t1_sub1 = array_loaded['data_t1_cropped']
-        labels_sub1 = array_loaded['label_cropped']
+        labels_sub1  = array_loaded['label_cropped']
+
         if is_weighted:
             GM_distance_sub1 = array_loaded['gmdist_cropped']
             ventdistmap_sub1 = array_loaded['ventdist_cropped']
 
-        if plane == 'axial':
-            if data_sub1 is not None:
-                data_sub1 = data_sub1.transpose(2, 0, 1)
-                data = np.concatenate(
-                    (data, resize(data_sub1, [data_sub1.shape[0], 128, 192], preserve_range=True)),
-                    axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 192],
-                                                     preserve_range=True)
-            if data_t1_sub1 is not None:
-                data_t1_sub1 = data_t1_sub1.transpose(2,0,1)
-                data_t1 = np.concatenate((data_t1,
-                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], 128, 192],
-                                                 preserve_range=True)), axis=0) if data_t1.size else resize(
-                    data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 192], preserve_range=True)
-            labels_sub1 = labels_sub1.transpose(2,0,1)
-            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],128,192],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],128,192],preserve_range=True)>0.5).astype(float)
-            if is_weighted:
-                GM_distance_sub1 = GM_distance_sub1.transpose(2, 0, 1)
-                ventdistmap_sub1 = ventdistmap_sub1.transpose(2, 0, 1)
-                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,192],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,192],preserve_range=True)
-                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,192],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,192],preserve_range=True)
-        elif plane == 'sagittal':
-            if data_sub1 is not None:
-                data = np.concatenate((data, resize(data_sub1,[data_sub1.shape[0],192,120],preserve_range=True)),axis=0) if data.size else resize(data_sub1,[data_sub1.shape[0],192,120],preserve_range=True)
-            if data_t1_sub1 is not None:
-                data_t1 = np.concatenate((data_t1, resize(data_t1_sub1,[data_t1_sub1.shape[0],192,120],preserve_range=True)),axis=0) if data_t1.size else resize(data_t1_sub1,[data_t1_sub1.shape[0],192,120],preserve_range=True)
-            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],192,120],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],192,120],preserve_range=True)>0.5).astype(float)
-            if is_weighted:
-                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],192,120],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],192,120],preserve_range=True)
-                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],192,120],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],192,120],preserve_range=True)
-        elif plane == 'coronal':
-            if data_sub1 is not None:
-                data_sub1 = data_sub1.transpose(1,0,2)
-                data = np.concatenate(
-                    (data, resize(data_sub1, [data_sub1.shape[0], 128, 80], preserve_range=True)),
-                    axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], 128, 80],
-                                                     preserve_range=True)
-            if data_t1_sub1 is not None:
-                data_t1_sub1 = data_t1_sub1.transpose(1,0,2)
-                data_t1 = np.concatenate((data_t1,
-                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], 128, 80],
-                                                 preserve_range=True)), axis=0) if data_t1.size else resize(
-                    data_t1_sub1, [data_t1_sub1.shape[0], 128, 80], preserve_range=True)
+        if data_sub1 is not None:
+            data = append(data, data_sub1)
 
-            labels_sub1 = labels_sub1.transpose(1,0,2)
-            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],128,80],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],128,80],preserve_range=True)>0.5).astype(float)
-            if is_weighted:
-                GM_distance_sub1 = GM_distance_sub1.transpose(1, 0, 2)
-                ventdistmap_sub1 = ventdistmap_sub1.transpose(1, 0, 2)
-                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,80],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,80],preserve_range=True)
-                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,80],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,80],preserve_range=True)
+        if data_t1_sub1 is not None:
+            data_t1 = append(data_t1, data_t1_sub1)
 
-    if data_sub1 is None:
-        data = None
-    else:
+        labels = append(labels, labels_sub1, binarise=True)
+
+        if is_weighted:
+            GM_distance = append(GM_distance, GM_distance_sub1)
+            ventdistmap = append(ventdistmap, ventdistmap_sub1)
+
+    if data.size:
         data = np.tile(data,(1,1,1,1))
         data = data.transpose(1,2,3,0)
-    if data_t1_sub1 is None:
-        data_t1 = None
     else:
+        data = None
+
+    if data_t1.size:
         data_t1 = np.tile(data_t1,(1,1,1,1))
         data_t1 = data_t1.transpose(1,2,3,0)
+    else:
+        data_t1 = None
+
     labels = np.tile(labels,(1,1,1,1))
     labels = labels.transpose(1,2,3,0)
 
     input_data = {'flair': data, 't1': data_t1, 'label': labels, 'gmdist':None, 'ventdist':None}
     if is_weighted:
-        input_data['gmdist'] = GM_distance
+        input_data['gmdist']   = GM_distance
         input_data['ventdist'] = ventdistmap
     return input_data
 

--- a/truenet/true_net/truenet_data_preparation.py
+++ b/truenet/true_net/truenet_data_preparation.py
@@ -36,22 +36,22 @@ def create_data_array(names, is_weighted=True, plane='axial'):
             if data_sub1 is not None:
                 data_sub1 = data_sub1.transpose(2, 0, 1)
                 data = np.concatenate(
-                    (data, resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 192], preserve_range=True)),
+                    (data, resize(data_sub1, [data_sub1.shape[0], 128, 192], preserve_range=True)),
                     axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 192],
                                                      preserve_range=True)
             if data_t1_sub1 is not None:
                 data_t1_sub1 = data_t1_sub1.transpose(2,0,1)
                 data_t1 = np.concatenate((data_t1,
-                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 192],
+                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], 128, 192],
                                                  preserve_range=True)), axis=0) if data_t1.size else resize(
                     data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 192], preserve_range=True)
             labels_sub1 = labels_sub1.transpose(2,0,1)
-            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],labels_sub1.shape[1],192],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],labels_sub1.shape[1],192],preserve_range=True)>0.5).astype(float)
+            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],128,192],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],128,192],preserve_range=True)>0.5).astype(float)
             if is_weighted:
                 GM_distance_sub1 = GM_distance_sub1.transpose(2, 0, 1)
                 ventdistmap_sub1 = ventdistmap_sub1.transpose(2, 0, 1)
-                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],GM_distance_sub1.shape[1],192],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],GM_distance_sub1.shape[1],192],preserve_range=True)
-                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],ventdistmap_sub1.shape[1],192],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],ventdistmap_sub1.shape[1],192],preserve_range=True)
+                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,192],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,192],preserve_range=True)
+                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,192],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,192],preserve_range=True)
         elif plane == 'sagittal':
             if data_sub1 is not None:
                 data = np.concatenate((data, resize(data_sub1,[data_sub1.shape[0],192,120],preserve_range=True)),axis=0) if data.size else resize(data_sub1,[data_sub1.shape[0],192,120],preserve_range=True)
@@ -65,23 +65,23 @@ def create_data_array(names, is_weighted=True, plane='axial'):
             if data_sub1 is not None:
                 data_sub1 = data_sub1.transpose(1,0,2)
                 data = np.concatenate(
-                    (data, resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 80], preserve_range=True)),
-                    axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 80],
+                    (data, resize(data_sub1, [data_sub1.shape[0], 128, 80], preserve_range=True)),
+                    axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], 128, 80],
                                                      preserve_range=True)
             if data_t1_sub1 is not None:
                 data_t1_sub1 = data_t1_sub1.transpose(1,0,2)
                 data_t1 = np.concatenate((data_t1,
-                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 80],
+                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], 128, 80],
                                                  preserve_range=True)), axis=0) if data_t1.size else resize(
-                    data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 80], preserve_range=True)
+                    data_t1_sub1, [data_t1_sub1.shape[0], 128, 80], preserve_range=True)
 
             labels_sub1 = labels_sub1.transpose(1,0,2)
-            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],labels_sub1.shape[1],80],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],labels_sub1.shape[1],80],preserve_range=True)>0.5).astype(float)
+            labels = np.concatenate((labels, (resize(labels_sub1,[labels_sub1.shape[0],128,80],preserve_range=True)>0.5).astype(float)),axis=0) if labels.size else (resize(labels_sub1,[labels_sub1.shape[0],128,80],preserve_range=True)>0.5).astype(float)
             if is_weighted:
                 GM_distance_sub1 = GM_distance_sub1.transpose(1, 0, 2)
                 ventdistmap_sub1 = ventdistmap_sub1.transpose(1, 0, 2)
-                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],GM_distance_sub1.shape[1],80],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],GM_distance_sub1.shape[1],80],preserve_range=True)
-                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],ventdistmap_sub1.shape[1],80],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],ventdistmap_sub1.shape[1],80],preserve_range=True)
+                GM_distance = np.concatenate((GM_distance, resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,80],preserve_range=True)),axis=0) if GM_distance.size else resize(GM_distance_sub1,[GM_distance_sub1.shape[0],128,80],preserve_range=True)
+                ventdistmap = np.concatenate((ventdistmap, resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,80],preserve_range=True)),axis=0) if ventdistmap.size else resize(ventdistmap_sub1,[ventdistmap_sub1.shape[0],128,80],preserve_range=True)
 
     if data_sub1 is None:
         data = None
@@ -126,22 +126,23 @@ def load_and_crop_data(data_path, weighted=True):
         labels_sub[labels_sub > 1.5] = 0
         data_t1_sub_org = nib.load(t1_path).get_fdata()
         _, coords = truenet_data_preprocessing.tight_crop_data(data_t1_sub_org)
-        row_cent = coords[1] // 2 + coords[0]
-        rowstart = np.amax([row_cent - 64, 0])
-        rowend = np.amin([row_cent + 64, data_t1_sub_org.shape[0]])
-        colstart = coords[2]
-        colend = coords[2] + coords[3]
+        rowstart   = coords[0]
+        rowend     = coords[0] + coords[1]
+        colstart   = coords[2]
+        colend     = coords[2] + coords[3]
         stackstart = coords[4]
-        stackend = coords[4] + coords[5]
-        data_t1_sub1 = np.zeros([128, coords[3], coords[5]])
+        stackend   = coords[4] + coords[5]
+        data_t1_sub1 = np.zeros([coords[1], coords[3], coords[5]])
         data_t1_sub_piece = truenet_data_preprocessing.preprocess_data_gauss(
             data_t1_sub_org[rowstart:rowend, colstart:colend, stackstart:stackend])
-        data_t1_sub1[:data_t1_sub_piece.shape[0], :data_t1_sub_piece.shape[1],
-        :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
-        labels_sub1 = np.zeros([128, coords[3], coords[5]])
+        data_t1_sub1[:data_t1_sub_piece.shape[0],
+                     :data_t1_sub_piece.shape[1],
+                     :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
+        labels_sub1 = np.zeros([coords[1], coords[3], coords[5]])
         labels_sub_piece = labels_sub[rowstart:rowend, colstart:colend, stackstart:stackend]
-        labels_sub1[:labels_sub_piece.shape[0], :labels_sub_piece.shape[1],
-        :labels_sub_piece.shape[2]] = labels_sub_piece
+        labels_sub1[:labels_sub_piece.shape[0],
+                    :labels_sub_piece.shape[1],
+                    :labels_sub_piece.shape[2]] = labels_sub_piece
         loaded_array['data_t1_cropped'] = data_t1_sub1
         loaded_array['label_cropped'] = labels_sub1
     else:
@@ -149,38 +150,41 @@ def load_and_crop_data(data_path, weighted=True):
         labels_sub[labels_sub > 1.5] = 0
         data_sub_org = nib.load(flair_path).get_fdata()
         _, coords = truenet_data_preprocessing.tight_crop_data(data_sub_org)
-        row_cent = coords[1] // 2 + coords[0]
-        rowstart = np.amax([row_cent - 64, 0])
-        rowend = np.amin([row_cent + 64, data_sub_org.shape[0]])
-        colstart = coords[2]
-        colend = coords[2] + coords[3]
+        rowstart   = coords[0]
+        rowend     = coords[0] + coords[1]
+        colstart   = coords[2]
+        colend     = coords[2] + coords[3]
         stackstart = coords[4]
-        stackend = coords[4] + coords[5]
-        data_sub1 = np.zeros([128, coords[3], coords[5]])
+        stackend   = coords[4] + coords[5]
+        data_sub1 = np.zeros([coords[1], coords[3], coords[5]])
         data_sub_piece = truenet_data_preprocessing.preprocess_data_gauss(
             data_sub_org[rowstart:rowend, colstart:colend, stackstart:stackend])
-        data_sub1[:data_sub_piece.shape[0], :data_sub_piece.shape[1], :data_sub_piece.shape[2]] = data_sub_piece
-        labels_sub1 = np.zeros([128, coords[3], coords[5]])
+        data_sub1[:data_sub_piece.shape[0],
+                  :data_sub_piece.shape[1],
+                  :data_sub_piece.shape[2]] = data_sub_piece
+        labels_sub1 = np.zeros([coords[1], coords[3], coords[5]])
         labels_sub_piece = labels_sub[rowstart:rowend, colstart:colend, stackstart:stackend]
-        labels_sub1[:labels_sub_piece.shape[0], :labels_sub_piece.shape[1],
-        :labels_sub_piece.shape[2]] = labels_sub_piece
+        labels_sub1[:labels_sub_piece.shape[0],
+                    :labels_sub_piece.shape[1],
+                    :labels_sub_piece.shape[2]] = labels_sub_piece
         loaded_array['data_cropped'] = data_sub1
         loaded_array['label_cropped'] = labels_sub1
         if t1_path is not None:
             data_t1_sub_org = nib.load(t1_path).get_fdata()
-            data_t1_sub1 = np.zeros([128, coords[3], coords[5]])
+            data_t1_sub1 = np.zeros([coords[1], coords[3], coords[5]])
             data_t1_sub_piece = truenet_data_preprocessing.preprocess_data_gauss(
                 data_t1_sub_org[rowstart:rowend, colstart:colend, stackstart:stackend])
-            data_t1_sub1[:data_t1_sub_piece.shape[0], :data_t1_sub_piece.shape[1],
-            :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
+            data_t1_sub1[:data_t1_sub_piece.shape[0],
+                         :data_t1_sub_piece.shape[1],
+                         :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
             loaded_array['data_t1_cropped'] = data_t1_sub1
     if weighted:
         gmdist_path = data_path['gmdist_path']
         ventdist_path = data_path['ventdist_path']
         GM_distance_sub = nib.load(gmdist_path).get_fdata()
         ventdistmap_sub = nib.load(ventdist_path).get_fdata()
-        GM_distance_sub1 = np.zeros([128,coords[3],coords[5]])
-        ventdistmap_sub1 = np.zeros([128,coords[3],coords[5]])
+        GM_distance_sub1 = np.zeros([coords[1],coords[3],coords[5]])
+        ventdistmap_sub1 = np.zeros([coords[1],coords[3],coords[5]])
         GM_distance_sub_piece = GM_distance_sub[rowstart:rowend,colstart:colend,stackstart:stackend]
         ventdistmap_sub_piece = ventdistmap_sub[rowstart:rowend,colstart:colend,stackstart:stackend]
         GM_distance_sub1[:GM_distance_sub_piece.shape[0],:GM_distance_sub_piece.shape[1],:GM_distance_sub_piece.shape[2]] = GM_distance_sub_piece
@@ -369,63 +373,40 @@ def create_test_data_array(names, plane='axial'):
     Create the input stack of 2D slices reshaped to required dimensions
     :param names: list of dictionaries containing filepaths
     :param plane: acquisition plane
-    :return: dictionary of input arrays
+    :return: input array
     '''
-    data = np.array([])
+    data    = np.array([])
     data_t1 = np.array([])
+
+    def append(dest, arr):
+
+        if plane == 'axial':
+            arr   = arr.transpose(2, 0, 1)
+            shape = [arr.shape[0], 128, 192]
+
+        elif plane == 'sagittal':
+            shape = [data_sub1.shape[0], 192, 120]
+
+        elif plane == 'coronal':
+            arr   = arr.transpose(1, 0, 2)
+            shape = [arr.shape[0], 128, 80]
+
+        arr = resize(arr, shape, preserve_range=True)
+
+        if dest is not None and dest.size:
+            return np.concatenate((dest, arr), axis=0)
+        else:
+            return arr
 
     for i in range(len(names)):
         array_loaded = load_and_crop_test_data(names[i])
-        data_sub1 = array_loaded['data_cropped']
+        data_sub1    = array_loaded['data_cropped']
         data_t1_sub1 = array_loaded['data_t1_cropped']
-        if plane == 'axial':
-            if data_sub1 is not None:
-                data_sub1 = data_sub1.transpose(2, 0, 1)
-                data = np.concatenate(
-                    (data, resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 192], preserve_range=True)),
-                    axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 192],
-                                                     preserve_range=True)
-            else:
-                data = None
-            if data_t1_sub1 is not None:
-                data_t1_sub1 = data_t1_sub1.transpose(2, 0, 1)
-                data_t1 = np.concatenate((data_t1,
-                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 192],
-                                                 preserve_range=True)), axis=0) if data_t1.size else resize(
-                    data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 192], preserve_range=True)
-            else:
-                data_t1 = None
-        elif plane == 'sagittal':
-            if data_sub1 is not None:
-                data = np.concatenate((data, resize(data_sub1, [data_sub1.shape[0], 192, 120], preserve_range=True)),
-                                      axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], 192, 120],
-                                                                       preserve_range=True)
-            else:
-                data = None
-            if data_t1_sub1 is not None:
-                data_t1 = np.concatenate(
-                    (data_t1, resize(data_t1_sub1, [data_t1_sub1.shape[0], 192, 120], preserve_range=True)),
-                    axis=0) if data_t1.size else resize(data_t1_sub1, [data_t1_sub1.shape[0], 192, 120],
-                                                        preserve_range=True)
-            else:
-                data_t1 = None
-        elif plane == 'coronal':
-            if data_sub1 is not None:
-                data_sub1 = data_sub1.transpose(1, 0, 2)
-                data = np.concatenate(
-                    (data, resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 80], preserve_range=True)),
-                    axis=0) if data.size else resize(data_sub1, [data_sub1.shape[0], data_sub1.shape[1], 80],
-                                                     preserve_range=True)
-            else:
-                data = None
-            if data_t1_sub1 is not None:
-                data_t1_sub1 = data_t1_sub1.transpose(1, 0, 2)
-                data_t1 = np.concatenate((data_t1,
-                                          resize(data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 80],
-                                                 preserve_range=True)), axis=0) if data_t1.size else resize(
-                    data_t1_sub1, [data_t1_sub1.shape[0], data_t1_sub1.shape[1], 80], preserve_range=True)
-            else:
-                data_t1 = None
+
+        if data_sub1 is not None:
+            data = append(data, data_sub1)
+        if data_t1_sub1 is not None:
+            data_t1 = append(data_t1, data_t1_sub1)
 
     if data is not None and data_t1 is not None:
         data = np.tile(data, (1, 1, 1, 1))
@@ -441,8 +422,7 @@ def create_test_data_array(names, plane='axial'):
         data_t1 = np.tile(data_t1, (1, 1, 1, 1))
         data_t1 = data_t1.transpose(1, 2, 3, 0)
         tr_data = data_t1
-    data2d = [tr_data]
-    return data2d
+    return tr_data
 
 
 def load_and_crop_test_data(data_path):
@@ -461,40 +441,42 @@ def load_and_crop_test_data(data_path):
     if flair_path is None:
         data_t1_sub_org = nib.load(t1_path).get_fdata()
         _, coords = truenet_data_preprocessing.tight_crop_data(data_t1_sub_org)
-        row_cent = coords[1] // 2 + coords[0]
-        rowstart = np.amax([row_cent - 64, 0])
-        rowend = np.amin([row_cent + 64, data_t1_sub_org.shape[0]])
-        colstart = coords[2]
-        colend = coords[2] + coords[3]
+        rowstart   = coords[0]
+        rowend     = coords[0] + coords[1]
+        colstart   = coords[2]
+        colend     = coords[2] + coords[3]
         stackstart = coords[4]
-        stackend = coords[4] + coords[5]
-        data_t1_sub1 = np.zeros([128, coords[3], coords[5]])
+        stackend   = coords[4] + coords[5]
+        data_t1_sub1 = np.zeros([coords[1], coords[3], coords[5]])
         data_t1_sub_piece = truenet_data_preprocessing.preprocess_data_gauss(
             data_t1_sub_org[rowstart:rowend, colstart:colend, stackstart:stackend])
-        data_t1_sub1[:data_t1_sub_piece.shape[0], :data_t1_sub_piece.shape[1],
-        :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
+        data_t1_sub1[:data_t1_sub_piece.shape[0],
+                     :data_t1_sub_piece.shape[1],
+                     :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
         loaded_array['data_t1_cropped'] = data_t1_sub1
     else:
         data_sub_org = nib.load(flair_path).get_fdata()
         _, coords = truenet_data_preprocessing.tight_crop_data(data_sub_org)
-        row_cent = coords[1] // 2 + coords[0]
-        rowstart = np.amax([row_cent - 64, 0])
-        rowend = np.amin([row_cent + 64, data_sub_org.shape[0]])
-        colstart = coords[2]
-        colend = coords[2] + coords[3]
+        rowstart   = coords[0]
+        rowend     = coords[0] + coords[1]
+        colstart   = coords[2]
+        colend     = coords[2] + coords[3]
         stackstart = coords[4]
-        stackend = coords[4] + coords[5]
-        data_sub1 = np.zeros([128, coords[3], coords[5]])
+        stackend   = coords[4] + coords[5]
+        data_sub1 = np.zeros([coords[1], coords[3], coords[5]])
         data_sub_piece = truenet_data_preprocessing.preprocess_data_gauss(
             data_sub_org[rowstart:rowend, colstart:colend, stackstart:stackend])
-        data_sub1[:data_sub_piece.shape[0], :data_sub_piece.shape[1], :data_sub_piece.shape[2]] = data_sub_piece
+        data_sub1[:data_sub_piece.shape[0],
+                  :data_sub_piece.shape[1],
+                  :data_sub_piece.shape[2]] = data_sub_piece
         loaded_array['data_cropped'] = data_sub1
         if t1_path is not None:
             data_t1_sub_org = nib.load(t1_path).get_fdata()
-            data_t1_sub1 = np.zeros([128, coords[3], coords[5]])
+            data_t1_sub1 = np.zeros([coords[1], coords[3], coords[5]])
             data_t1_sub_piece = truenet_data_preprocessing.preprocess_data_gauss(
                 data_t1_sub_org[rowstart:rowend, colstart:colend, stackstart:stackend])
-            data_t1_sub1[:data_t1_sub_piece.shape[0], :data_t1_sub_piece.shape[1],
-            :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
+            data_t1_sub1[:data_t1_sub_piece.shape[0],
+                         :data_t1_sub_piece.shape[1],
+                         :data_t1_sub_piece.shape[2]] = data_t1_sub_piece
             loaded_array['data_t1_cropped'] = data_t1_sub1
     return loaded_array

--- a/truenet/true_net/truenet_data_preparation.py
+++ b/truenet/true_net/truenet_data_preparation.py
@@ -369,7 +369,7 @@ def create_test_data_array(names, plane='axial'):
             shape = [arr.shape[0], 128, 192]
 
         elif plane == 'sagittal':
-            shape = [data_sub1.shape[0], 192, 120]
+            shape = [arr.shape[0], 192, 120]
 
         elif plane == 'coronal':
             arr   = arr.transpose(1, 0, 2)

--- a/truenet/true_net/truenet_evaluate.py
+++ b/truenet/true_net/truenet_evaluate.py
@@ -24,7 +24,7 @@ def evaluate_truenet(test_name_dicts, model, test_params, device, mode='axial', 
     :return: predicted probability array
     '''
     testdata = truenet_data_preparation.create_test_data_array(test_name_dicts, plane=mode)
-    data = testdata[0].transpose(0,3,1,2)
+    data = testdata.transpose(0,3,1,2)
 
     test_dataset_dict = truenet_dataset_utils.WMHTestDataset(data)
     test_dataloader = DataLoader(test_dataset_dict, batch_size=1, shuffle=False, num_workers=0)

--- a/truenet/true_net/truenet_evaluate.py
+++ b/truenet/true_net/truenet_evaluate.py
@@ -11,19 +11,6 @@ from truenet.utils import truenet_dataset_utils
 # 10-03-2021, Oxford
 #=========================================================================================
 
-def dice_coeff(inp, tar):
-    '''
-    Calculating Dice similarity coefficient
-    :param inp: Input tensor
-    :param tar: Target tensor
-    :return: Dice value (scalar)
-    '''
-    smooth = 1.
-    pred_vect = inp.contiguous().view(-1)
-    target_vect = tar.contiguous().view(-1)
-    intersection = (pred_vect * target_vect).sum()
-    dice = (2. * intersection + smooth) / (torch.sum(pred_vect) + torch.sum(target_vect) + smooth)
-    return dice
 
 def evaluate_truenet(test_name_dicts, model, test_params, device, mode='axial', verbose=False):
     '''


### PR DESCRIPTION
Truenet currently limits the image FOV to 128 voxels along the LR axis. This causes the FOV to be severely cropped for images with high resolution along the LR axis. This can be seen in the FSL course dataset, which has dimensions (256, 256, 35):

```bash
cd ~/fsl_course_data/truenet/
mkdir truenet_results
truenet evaluate -m mwsc -i sub-001 -o truenet_results
```

<img width="1300" height="573" alt="orig" src="https://github.com/user-attachments/assets/a0f2a6af-bb96-4237-92b9-4b4d52b3e676" />


We can see that the left/right extremities of the image are cropped. This isn't really a problem here, as the FOV does contain all brain regions which are likely to contain white matter hyperintensities.

However, this does become a problem for images with high resolution along the LR axis - for example, if we up-sample the FSL course dataset to (512, 256, 35):

```bash
cp -r sub-001 sub-001-highres
for f in sub-001-highres/*gz; do
  $FSLDIR/bin/resample_image $f $f -s 512,256,35
done
mkdir truenet_results_highres
truenet evaluate -m mwsc -i sub-001-highres -o truenet_results_highres
```

<img width="1300" height="573" alt="orig_highres" src="https://github.com/user-attachments/assets/58740248-cc03-4d03-bb8d-521c0e5fe6e1" />



This is happening because:
 - When truenet loads the input images, it finds the tightest bounding box that contains the entire (brain-extracted) input image - this takes place in the [`tight_crop_data`  	function.](https://github.com/v-sundaresan/truenet/blob/4c539165932f7f0607693363731fe5d4e8356590/truenet/true_net/truenet_data_preprocessing.py#L33-L57).
 - However, only the bounds for the second and third axes (PA, IS) are used to crop the images - for the first axis (LR), the image is cropped to the central 128 voxels. This happens in a few places, for example within the [`load_and_crop_test_data` function](https://github.com/v-sundaresan/truenet/blob/4c539165932f7f0607693363731fe5d4e8356590/truenet/true_net/truenet_data_preparation.py#L478-L491).
 - After the input images are cropped, they are resampled to the required dimensions (using [`skimage.transform.resize`](https://scikit-image.org/docs/stable/api/skimage.transform.html#skimage.transform.resize).

This does kind of agree with the [main Truenet reference](https://doi.org/10.1016/j.media.2021.102184)  (section 2.1.1 _Preprocessing_) - the sagittal and coronal planes are both cropped _and_ resized (resampled), whereas the axial plane is only cropped:

> We then extracted 2D slices from the volumes from all three planes. For the axial plane, we cropped the slices to a dimension of 128 × 192 voxels. For sagittal and coronal slices, we cropped and resized the extracted slices to 192 × 120 and 128 × 80 voxels respectively, using bilinear interpolation

Why is the image cropping implemented this way? It is obviously a problem for images with high resolution along the LR axis. I can only assume that the LR axis size was hard-coded at 128 during early development, but was never updated.

This PR updates the relevant code so that the LR axis is treated the same as the PA and IS axes - i.e. the image is cropped to the smallest bounding box that contains the brain, and then resampled to the required resolution. Running `truenet evaluate` on the original and up-sampled FSL course dataset now produces probability maps that contain the entire brain:

```
mkdir truenet_results_new
truenet evaluate -m mwsc -i sub-001 -o truenet_results_new
```

<img width="1300" height="573" alt="new" src="https://github.com/user-attachments/assets/24e5c89a-83c6-4b3f-8598-cfae701f04d6" />



```
mkdir truenet_results_new_highres
truenet evaluate -m mwsc -i sub-001-highres -o truenet_results_new_highres
```

<img width="1300" height="573" alt="new_highres" src="https://github.com/user-attachments/assets/8fa0a75f-4335-4b37-b133-cc5b85989a9d" />

